### PR TITLE
modify : 중복되는 이미지 버튼 리팩토링 및 관련 컴포넌트 수정

### DIFF
--- a/src/components/emojiModal/EmojiModal.tsx
+++ b/src/components/emojiModal/EmojiModal.tsx
@@ -1,6 +1,7 @@
 import axios from "axios";
 import React, { Dispatch, SetStateAction, useState } from "react";
 import { useParams } from "react-router";
+import closeImg from "../../assets/icon-close.svg";
 import {
   ModalWrapper,
   ContentsWrapper,
@@ -11,7 +12,7 @@ import {
   ModalOver,
   PostMargin,
 } from "./style";
-import { BasicBtn, CloseBtn } from "../../elements/button/Button";
+import { BasicBtn, ImageBtn } from "../../elements/button/Button";
 
 import Post from "../post/Post";
 import {
@@ -32,8 +33,8 @@ interface PostDataProps {
 interface ModalProps {
   setIsModalShow: Dispatch<SetStateAction<boolean>>;
   setPostData:
-    | Dispatch<SetStateAction<PostDataProps[] | undefined>>
-    | undefined;
+  | Dispatch<SetStateAction<PostDataProps[] | undefined>>
+  | undefined;
   isModalShow: boolean;
   setPost: () => void;
 }
@@ -114,7 +115,12 @@ const EmojiModal: React.FC<ModalProps> = ({
   return (
     <ModalOver className={isModalShow ? "" : "hide"}>
       <ModalWrapper>
-        <CloseBtn top="0" right="-150px" onClick={closeModal} />
+        <ImageBtn
+          width="25px"
+          height="25px"
+          src={closeImg}
+          onClick={closeModal}
+        />
         <ContentsWrapper>
           <ContentBox>
             <TitleText>1. 스티커를 골라볼까요?</TitleText>

--- a/src/components/emojiModal/EmojiModal.tsx
+++ b/src/components/emojiModal/EmojiModal.tsx
@@ -39,12 +39,12 @@ interface ModalProps {
   setPost: () => void;
 }
 
-const EmojiModal: React.FC<ModalProps> = ({
+const EmojiModal = ({
   setIsModalShow,
   isModalShow,
   setPostData,
   setPost,
-}) => {
+}: ModalProps): JSX.Element => {
   const { id } = useParams();
 
   // Post 추가 API
@@ -115,12 +115,6 @@ const EmojiModal: React.FC<ModalProps> = ({
   return (
     <ModalOver className={isModalShow ? "" : "hide"}>
       <ModalWrapper>
-        <ImageBtn
-          width="25px"
-          height="25px"
-          src={closeImg}
-          onClick={closeModal}
-        />
         <ContentsWrapper>
           <ContentBox>
             <TitleText>1. 스티커를 골라볼까요?</TitleText>
@@ -155,6 +149,15 @@ const EmojiModal: React.FC<ModalProps> = ({
           </ContentBox>
         </ContentsWrapper>
         <BasicBtn onClick={onClickAddBtn}>저장</BasicBtn>
+        <ImageBtn
+          position="fixed"
+          top="15px"
+          right="15px"
+          width="25px"
+          height="25px"
+          src={closeImg}
+          onClick={closeModal}
+        ><span className="ir">닫기 버튼</span></ImageBtn>
       </ModalWrapper>
     </ModalOver>
   );

--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -86,12 +86,14 @@ const Post = ({
         {!isInput && (
           <PostCloseBtn
             className={done || prevData}
-            alt="포스트 삭제"
-            width={15}
-            height={15}
+            position="absolute"
+            top="8px"
+            right="8px"
+            width="15px"
+            height="15px"
             src={CloseBtn}
             onClick={ShowDeleteModal}
-          />
+          ><span className="ir">포스트 삭제 버튼</span></PostCloseBtn>
         )}
       </PostArticle>
       {isModalState && (

--- a/src/components/post/style.ts
+++ b/src/components/post/style.ts
@@ -1,6 +1,7 @@
 import styled from "styled-components";
+import { ImgBtn } from "../../elements/button/style";
 
-const PostArticle = styled.article<{ bgColor: string }>`
+const PostArticle = styled.li<{ bgColor: string }>`
   width: 250px;
   height: 250px;
   clip-path: polygon(100% 0, 100% 100%, 15% 100%, 0 85%, 0 0);
@@ -43,14 +44,8 @@ const PostEdge = styled.div<{ shadowColor: string }>`
   background-color: ${props => props.shadowColor};
 `;
 
-const PostCloseBtn = styled.img<{ prevData?: string }>`
+const PostCloseBtn = styled(ImgBtn)<{ prevData?: string }>`
   display: ${props => props.prevData};
-  width: 15px;
-  height: 15px;
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  cursor: pointer;
 `;
 
 export {

--- a/src/components/shareModal/Share.tsx
+++ b/src/components/shareModal/Share.tsx
@@ -2,8 +2,10 @@ import * as React from "react";
 import { PropsWithChildren, useEffect, useState } from "react";
 // import { Helmet } from "react-helmet";
 import { DialogBox, LinkBox, Backdrop, Copied, Text } from "./style";
-import { KakaoBtn, CloseBtn, CopyBtn } from "../../elements/button/Button";
+import { KakaoBtn, ImageBtn } from "../../elements/button/Button";
 import kakaoShare from "./kakao";
+import copyImg from "../../assets/icon-copy.svg";
+import closeImg from "../../assets/icon-close.svg";
 
 interface ModalDefaultType {
   onClickToggleModal: () => void;
@@ -33,9 +35,10 @@ const Share = ({
   return (
     <>
       <DialogBox>
-        <CloseBtn
-          bottom="10px"
-          left="330px"
+        <ImageBtn
+          width="25px"
+          height="25px"
+          src={closeImg}
           onClick={() => {
             if (onClickToggleModal) {
               onClickToggleModal();
@@ -56,7 +59,11 @@ const Share = ({
               });
           }}
         >
-          <CopyBtn bottom="15px" left="550px" />
+          <ImageBtn
+            width="25px"
+            height="25px"
+            src={copyImg}
+          />
           {children}
         </LinkBox>
         <Copied>{copied}</Copied>

--- a/src/elements/button/Button.tsx
+++ b/src/elements/button/Button.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useState, useCallback } from "react";
-import { Basic, Cancel, ShareSNS, Close, Copy, ShareLinkBtn } from "./style";
+import { Basic, Cancel, ShareSNS, ShareLinkBtn, ImgBtn } from "./style";
 import Share from "../../components/shareModal/Share";
 
 interface BtnProps {
@@ -9,11 +9,10 @@ interface BtnProps {
 }
 
 export interface ImgBtnProps {
-  top?: string;
-  bottom?: string;
-  left?: string;
-  right?: string;
-  display?: string;
+  width?: string;
+  height?: string;
+  src: string;
+  backgroundSize?: string;
   onClick?: (event: any) => void;
 }
 
@@ -33,42 +32,20 @@ const KakaoBtn = ({ onClick, children }: BtnProps) => {
   return <ShareSNS onClick={onClick}>카카오톡으로 공유하기</ShareSNS>;
 };
 
-const CloseBtn = ({
-  top,
-  bottom,
-  left,
-  right,
-  display,
-  onClick,
+const ImageBtn = ({
+  width,
+  height,
+  src,
+  backgroundSize,
+  onClick
 }: ImgBtnProps) => {
   return (
-    <Close
-      top={top ?? top}
-      bottom={bottom ?? bottom}
-      left={left ?? left}
-      right={right ?? right}
+    <ImgBtn
+      width={width ?? width}
+      height={height ?? height}
+      src={src}
+      backgroundSize={backgroundSize ?? backgroundSize}
       onClick={onClick}
-      display={display ?? display}
-    />
-  );
-};
-
-const CopyBtn = ({
-  top,
-  bottom,
-  left,
-  right,
-  display,
-  onClick,
-}: ImgBtnProps) => {
-  return (
-    <Copy
-      top={top ?? top}
-      bottom={bottom ?? bottom}
-      left={left ?? left}
-      right={right ?? right}
-      onClick={onClick}
-      display={display ?? display}
     />
   );
 };
@@ -122,4 +99,4 @@ const ShareLinkToReceiver = () => {
   );
 };
 
-export { BasicBtn, CancelBtn, KakaoBtn, CloseBtn, CopyBtn, ShareLinkToWriter, ShareLinkToReceiver };
+export { BasicBtn, CancelBtn, KakaoBtn, ImageBtn, ShareLinkToWriter, ShareLinkToReceiver };

--- a/src/elements/button/Button.tsx
+++ b/src/elements/button/Button.tsx
@@ -17,7 +17,6 @@ export interface ImgBtnProps {
   width?: string;
   height?: string;
   src: string;
-  backgroundSize?: string;
   onClick?: (event: any) => void;
   children?: React.ReactNode;
 }
@@ -47,7 +46,6 @@ const ImageBtn = ({
   width,
   height,
   src,
-  backgroundSize,
   onClick,
   children
 }: ImgBtnProps) => {
@@ -61,7 +59,6 @@ const ImageBtn = ({
       width={width ?? width}
       height={height ?? height}
       src={src}
-      backgroundSize={backgroundSize ?? backgroundSize}
       onClick={onClick}
     >{children}</ImgBtn>
   );

--- a/src/elements/button/Button.tsx
+++ b/src/elements/button/Button.tsx
@@ -9,11 +9,17 @@ interface BtnProps {
 }
 
 export interface ImgBtnProps {
+  position?: string;
+  top?: string;
+  right?: string;
+  bottom?: string;
+  left?: string;
   width?: string;
   height?: string;
   src: string;
   backgroundSize?: string;
   onClick?: (event: any) => void;
+  children?: React.ReactNode;
 }
 
 export interface ShareLinkProps {
@@ -33,20 +39,31 @@ const KakaoBtn = ({ onClick, children }: BtnProps) => {
 };
 
 const ImageBtn = ({
+  position,
+  top,
+  right,
+  bottom,
+  left,
   width,
   height,
   src,
   backgroundSize,
-  onClick
+  onClick,
+  children
 }: ImgBtnProps) => {
   return (
     <ImgBtn
+      position={position ?? position}
+      top={top ?? top}
+      right={right ?? right}
+      bottom={bottom ?? bottom}
+      left={left ?? left}
       width={width ?? width}
       height={height ?? height}
       src={src}
       backgroundSize={backgroundSize ?? backgroundSize}
       onClick={onClick}
-    />
+    >{children}</ImgBtn>
   );
 };
 

--- a/src/elements/button/style.ts
+++ b/src/elements/button/style.ts
@@ -58,9 +58,14 @@ export const ShareSNS = styled.button`
 `;
 
 export const ImgBtn = styled.button<ImgBtnProps>`
+  position: ${props => props.position};
+  top: ${props => props.top};
+  right: ${props => props.right};
+  bottom: ${props => props.bottom};
+  left: ${props => props.left};
   width: ${props => props.width};
   height: ${props => props.height};
-  background: url(${props => props.src}) no-repeat;
+  background: url(${props => props.src}) no-repeat center;
   background-size: ${props => props.backgroundSize};
   background-color: transparent;
   border: none;

--- a/src/elements/button/style.ts
+++ b/src/elements/button/style.ts
@@ -1,8 +1,6 @@
 import styled from "styled-components";
 import { ImgBtnProps, ShareLinkProps } from "./Button";
 import kakaoLogo from "../../assets/icon-kakao.svg";
-import copyImg from "../../assets/icon-copy.svg";
-import closeImg from "../../assets/icon-close.svg";
 
 export const Btn = styled.button`
   border: none;
@@ -59,29 +57,11 @@ export const ShareSNS = styled.button`
   }
 `;
 
-export const Close = styled.button<ImgBtnProps>`
-  background-image: url(${closeImg});
-  position: relative;
-  width: 25px;
-  height: 25px;
-  top: ${props => props.top};
-  bottom: ${props => props.bottom};
-  left: ${props => props.left};
-  right: ${props => props.right};
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-`;
-
-export const Copy = styled.button<ImgBtnProps>`
-  background-image: url(${copyImg});
-  position: relative;
-  width: 15px;
-  height: 15px;
-  top: ${props => props.top};
-  bottom: ${props => props.bottom};
-  left: ${props => props.left};
-  right: ${props => props.right};
+export const ImgBtn = styled.button<ImgBtnProps>`
+  width: ${props => props.width};
+  height: ${props => props.height};
+  background: url(${props => props.src}) no-repeat;
+  background-size: ${props => props.backgroundSize};
   background-color: transparent;
   border: none;
   cursor: pointer;

--- a/src/elements/button/style.ts
+++ b/src/elements/button/style.ts
@@ -66,10 +66,11 @@ export const ImgBtn = styled.button<ImgBtnProps>`
   width: ${props => props.width};
   height: ${props => props.height};
   background: url(${props => props.src}) no-repeat center;
-  background-size: ${props => props.backgroundSize};
+  background-size: cover;
   background-color: transparent;
   border: none;
   cursor: pointer;
+  padding: 0;
 `;
 
 export const ShareLinkBtn = styled.button<ShareLinkProps>`


### PR DESCRIPTION
* CloseBtn과 CopyBtn은 둘 다 이미지가 들어가는 이미지 버튼이며, styled-components가 중복되므로 ImageBtn으로 통합 및 스타일 수정
* button element에 position/top/right/bottom/left를 props로 설정하여 원하는 위치에 지정할 수 있도록 구현 
* 이모지 모달에서 웹접근성을 위하여 닫기버튼 태그를 맨 밑으로 이동
* img태그가 아니여서 alt가 없으므로 span태그로 설명 쓴뒤 ir로 가림
* Post.tsx에서 따로 구현되어있는 닫기(x)버튼(이미지태그로 되어있었음)을 element폴더 내의 버튼으로 재사용할 수 있도록 수정
* Post.tsx에서의 포스트가 ariticle태그로 되어있는데 Container.tsx에서 ul태그 안에 들어가는 부분이므로 li태그로 수정 

close #100 