### PR TITLE
:lipstick: add : 공유 모달창 미디어 쿼리 추가

### DIFF
--- a/src/components/shareModal/Share.tsx
+++ b/src/components/shareModal/Share.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { PropsWithChildren, useEffect, useState, useRef } from "react";
 // import { Helmet } from "react-helmet";
-import { DialogBox, LinkBox, Copied, Text, CloseBtn } from "./style";
+import { DialogBox, LinkBox, Copied, Text, CloseBtn, CopyBtn, ShareBtn } from "./style";
 import { KakaoBtn, ImageBtn } from "../../elements/button/Button";
 import { ModalOver } from "../emojiModal/style";
 import kakaoShare from "./kakao";
@@ -34,7 +34,7 @@ const Share = ({
   const outside = useRef() as React.RefObject<HTMLDivElement>;
   const closeTag = useRef() as React.RefObject<HTMLButtonElement>;
   const handleCloseModal = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    if(e.target === outside.current || e.target === closeTag.current){
+    if (e.target === outside.current || e.target === closeTag.current) {
       onClickToggleModal();
     }
   };
@@ -55,7 +55,7 @@ const Share = ({
       <DialogBox>
         <Text>당신의 SNS에 공유해주세요 :)</Text>
         <LinkBox onClick={handleCopyLink}>
-          <ImageBtn
+          <CopyBtn
             position="absolute"
             top="10px"
             right="10px"
@@ -64,18 +64,20 @@ const Share = ({
             src={copyImg}
           >
             <span className="ir">복사 버튼</span>
-          </ImageBtn>
+          </CopyBtn>
           {children}
         </LinkBox>
         <Copied>{copied}</Copied>
         {/* <Helmet>
           <script src="https://developers.kakao.com/sdk/js/kakao.js" />
         </Helmet> */}
-        <KakaoBtn
+        <ShareBtn
           onClick={() => {
             kakaoShare(selecteURL);
           }}
-        />
+        >
+          카카오톡으로 공유하기
+        </ShareBtn>
         <CloseBtn
           position="absolute"
           top="7px"

--- a/src/components/shareModal/style.ts
+++ b/src/components/shareModal/style.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { ImgBtn } from "../../elements/button/style";
+import { ImgBtn, ShareSNS } from "../../elements/button/style";
 
 const DialogBox = styled.dialog`
   position: relative;
@@ -18,7 +18,7 @@ const DialogBox = styled.dialog`
   margin: 0;
   @media (max-width: 680px) {
     width: 260px;
-    padding: 25px 20px;
+    padding: 20px;
   }
 `;
 
@@ -26,7 +26,8 @@ const Text = styled.p`
   font-size: 16px;
   margin-bottom: 20px;
   @media (max-width: 680px) {
-    margin: 0;
+    font-size: 14px;
+    margin-bottom: 10px;
   }
 `;
 
@@ -38,13 +39,42 @@ const LinkBox = styled.div`
   background-color: #efefef;
   cursor: pointer;
   @media (max-width: 680px) {
-    display: none;
+    font-size: 13px;
+    width: 100%;
+    padding: 15px;
+    word-wrap: break-word;
   }
 `;
 
 const Copied = styled.span`
   font-size: 16px;
   padding: 10px;
+  @media (max-width: 680px) {
+    font-size: 10px;
+    padding: 5px;
+  }
+  `;
+
+const CopyBtn = styled(ImgBtn)`
+  @media (max-width: 680px) {
+    top: 6px;
+    right: 6px;
+    width: 12px;
+    height: 12px;
+  }
+`;
+
+const ShareBtn = styled(ShareSNS)`
+  @media (max-width: 680px) {
+    font-size: 13px;
+    width: 100%;
+    justify-content: center;
+    gap: 5px;
+    &::before {
+      width: 26px;
+      height: 26px;
+    }
+  }
 `;
 
 const CloseBtn = styled(ImgBtn)`
@@ -52,6 +82,6 @@ const CloseBtn = styled(ImgBtn)`
     width: 15px;
     height: 15px;
   }
-` 
+`;
 
-export { DialogBox, LinkBox, Copied, Text, CloseBtn };
+export { DialogBox, LinkBox, Copied, Text, CloseBtn, CopyBtn, ShareBtn };

--- a/src/elements/button/Button.tsx
+++ b/src/elements/button/Button.tsx
@@ -25,6 +25,7 @@ export interface ShareLinkProps {
   text: string;
   selecteURL: string;
 }
+
 interface BasicProps {
   onClick: (event: {
     stopPropagation: () => void;
@@ -33,6 +34,7 @@ interface BasicProps {
   }) => void;
   children: React.ReactNode;
 }
+
 const BasicBtn = ({ onClick, children }: BasicProps) => {
   return <Basic onClick={onClick}>{children}</Basic>;
 };
@@ -48,7 +50,7 @@ const CancelBtn = ({ onClick, children }: BtnProps) => {
 const KakaoBtn = ({ onClick, children }: BtnProps) => {
   return (
     <ShareSNS onClick={onClick} type="button">
-      카카오톡으로 공유하기
+      {children}
     </ShareSNS>
   );
 };

--- a/src/elements/button/style.ts
+++ b/src/elements/button/style.ts
@@ -51,7 +51,6 @@ export const ShareSNS = styled.button`
     height: 40px;
     background: url(${kakaoLogo}) no-repeat center;
     background-size: cover;
-    float: left;
   }
   &:hover {
     filter: brightness(0.9);


### PR DESCRIPTION
* 모바일 사이즈의 화면 크기에서 공유 모달창에 있는 링크 복사 박스의 display가 none이었는데, 
이를 없애고 모바일에서도 링크 복사 박스를 볼 수 있도록 컴포넌트 및 스타일 수정

![ddd](https://user-images.githubusercontent.com/97039896/186849438-6bb20695-5fe9-4858-89f6-6cfe2eb734ad.gif)
