### PR TITLE
style : 생성된 board에서 타이틀 수정 button/input UI 구현

### DIFF
--- a/src/components/container/Container.tsx
+++ b/src/components/container/Container.tsx
@@ -14,6 +14,8 @@ import {
   BoardPostUl,
   BoardPrevButtonStyled,
   BoardTitleStyled,
+  TitleModifyBtn,
+  BoardTitleInput
 } from "./style";
 
 const Container = () => {
@@ -61,12 +63,41 @@ const Container = () => {
     }),
   );
 
+  const [isDisplay, setIsDisplay] = React.useState<boolean>(true);
+  const [btnName, setBtnName] = React.useState<string>("타이틀 수정하기");
+  const handleModifyBtn = () => {
+    if (isDisplay === true) {
+      setBtnName("수정 완료");
+    } else {
+      setBtnName("타이틀 수정하기");
+    }
+    setIsDisplay(!isDisplay);
+  };
+
   return (
     <ContainerStyled>
       <BoardHeaderStyled>
-        <BoardTitleStyled>
-          {titleData.data && titleData.data.content}
-        </BoardTitleStyled>
+        {
+          isDisplay &&
+          <BoardTitleStyled>
+            {titleData.data && titleData.data.content}
+          </BoardTitleStyled>
+        }
+        {
+          !isDisplay &&
+          <BoardTitleInput
+            isInput
+            height="auto"
+            bgColor="#EFEFEF"
+            placeholder={titleData.data && titleData.data.content}
+            id="title"
+            padding="10px"
+            fontSize="20px"
+            fontWeight="600" />
+        }
+        <TitleModifyBtn onClick={handleModifyBtn}>
+          {btnName}
+        </TitleModifyBtn>
         <BoardPrevButtonStyled className={done} onClick={setPrev}>
           {prevBtnVal}
         </BoardPrevButtonStyled>

--- a/src/components/container/Container.tsx
+++ b/src/components/container/Container.tsx
@@ -95,7 +95,7 @@ const Container = () => {
             fontSize="20px"
             fontWeight="600" />
         }
-        <TitleModifyBtn onClick={handleModifyBtn}>
+        <TitleModifyBtn className={done || prevData} onClick={handleModifyBtn}>
           {btnName}
         </TitleModifyBtn>
         <BoardPrevButtonStyled className={done} onClick={setPrev}>

--- a/src/components/container/style.ts
+++ b/src/components/container/style.ts
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { Basic } from "../../elements/button/style";
+import { InputEl } from "../../elements/input/style";
 
 export const ContainerStyled = styled.div`
   height: 80vh;
@@ -24,9 +25,12 @@ export const ContainerStyled = styled.div`
 
 export const BoardHeaderStyled = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 20px;
   padding: 0 37px 24px 30px;
+  @media (max-width: 680px) {
+    gap: 15px;
+  }
   @media (max-width: 460px) {
     flex-direction: column;
     gap: 10px;
@@ -50,8 +54,33 @@ export const BoardTitleStyled = styled.h2`
   }
 `;
 
+export const BoardTitleInput = styled(InputEl)`
+  width: 40%;
+  @media (max-width: 680px) {
+    width: 70%;
+    font-size: 14px;
+    padding: 7px;
+  }
+  @media (max-width: 460px) {
+    margin-bottom: 3px;
+  }
+`
+
+export const TitleModifyBtn = styled(Basic)`
+  width: 150px;
+  margin-left: auto;
+  white-space: nowrap;
+  @media (max-width: 680px) {
+    font-size: 16px;
+  }
+  @media (max-width: 460px) {
+    margin-left: 0;
+  }
+`;
+
 export const BoardPrevButtonStyled = styled(Basic)`
   width: 150px;
+  white-space: nowrap;
   @media (max-width: 680px) {
     font-size: 16px;
   }

--- a/src/components/container/style.ts
+++ b/src/components/container/style.ts
@@ -44,6 +44,7 @@ export const BoardTitleStyled = styled.h2`
   font-size: 40px;
   color: #977ae1;
   word-break: keep-all;
+  margin-right: auto;
   @media (max-width: 680px) {
     font-size: 20px;
   }
@@ -56,6 +57,7 @@ export const BoardTitleStyled = styled.h2`
 
 export const BoardTitleInput = styled(InputEl)`
   width: 40%;
+  margin-right: auto;
   @media (max-width: 680px) {
     width: 70%;
     font-size: 14px;
@@ -68,7 +70,6 @@ export const BoardTitleInput = styled(InputEl)`
 
 export const TitleModifyBtn = styled(Basic)`
   width: 150px;
-  margin-left: auto;
   white-space: nowrap;
   @media (max-width: 680px) {
     font-size: 16px;


### PR DESCRIPTION
* 타이틀을 입력하여 생성된 board에서 타이틀 수정이 가능한 버튼을 추가
* 버튼을 누르면 타이틀이 사라지고, 타이틀 수정이 가능한 Input form이 보이도록 UI 구현
* 완성본 미리보기 버튼을 클릭하면 타이틀 수정하기 버튼을 안보이게 구현
* 기능 구현은 다은님이 하실 예정

![dddddccc](https://user-images.githubusercontent.com/97039896/187035243-981e2242-6546-4e2b-b02c-f68d7d7f9e5f.gif)

